### PR TITLE
subsys: hio_atci: Add CRC32 (IEEE) support, extended error handling and temp buffer API

### DIFF
--- a/subsys/hio_atci/Kconfig
+++ b/subsys/hio_atci/Kconfig
@@ -42,9 +42,15 @@ config HIO_ATCI_PRINTF_BUFF_SIZE
 	  It is working like stdio buffering in Linux systems
 	  to limit number of peripheral access calls.
 
+config HIO_ATCI_CRC_ENABLED
+	bool "HIO_ATCI_CRC_ENABLED"
+	default y
+	help
+	  Enable CRC calculation for ATCI commands.
+	  It is used to verify command integrity.
+
 module = HIO_ATCI
 module-str = HIO ATCI Subsystem
 source "subsys/logging/Kconfig.template.log_config"
 
 endif # HIO_ATCI
-

--- a/subsys/hio_atci/hio_atci_cmd.c
+++ b/subsys/hio_atci/hio_atci_cmd.c
@@ -86,7 +86,7 @@ static int help_action(const struct hio_atci *atci, bool hint)
 		}
 
 		if (hint && item->hint) {
-			hio_atci_printfln(atci, "AT%s %s", item->cmd, item->hint);
+			hio_atci_printfln(atci, "AT%s \"%s\"", item->cmd, item->hint);
 		} else {
 			hio_atci_printfln(atci, "AT%s", item->cmd);
 		}
@@ -102,6 +102,34 @@ static int at_clac_action(const struct hio_atci *atci)
 HIO_ATCI_CMD_REGISTER(clac, "+CLAC", 0, at_clac_action, NULL, NULL, NULL,
 		      "Command list and action");
 
+static int at_crc_set(const struct hio_atci *atci, char *argv)
+{
+	if (!argv || strlen(argv) != 1) {
+		return -EINVAL;
+	}
+
+	if (strcmp(argv, "1") == 0) {
+		atci->ctx->crc_enabled = true;
+		return 0;
+	}
+
+	if (strcmp(argv, "0") == 0) {
+		atci->ctx->crc_enabled = false;
+		return 0;
+	}
+
+	return -EINVAL;
+}
+
+static int at_crc_read(const struct hio_atci *atci)
+{
+	hio_atci_printfln(atci, "$CRC: %d", atci->ctx->crc_enabled ? 1 : 0);
+
+	return 0;
+}
+
+HIO_ATCI_CMD_REGISTER(crc, "$CRC", 0, NULL, at_crc_set, at_crc_read, NULL, "CRC check");
+
 static int at_help_action(const struct hio_atci *atci)
 {
 	return help_action(atci, true);
@@ -109,7 +137,7 @@ static int at_help_action(const struct hio_atci *atci)
 HIO_ATCI_CMD_REGISTER(help, "$HELP", 0, at_help_action, NULL, NULL, NULL, "This help");
 
 #if defined(CONFIG_HIO_ATCI_CMD_SHELL)
-static int at_shell_set(const struct hio_atci *atci, const char *argv)
+static int at_shell_set(const struct hio_atci *atci, char *argv)
 {
 	if (!argv) {
 		return -EINVAL;


### PR DESCRIPTION

- Added CRC32 (IEEE 802.3) support with format validation and mismatch detection
- Extended default ATCI error responses for common errno cases
- Added hio_atci_get_tmp_buff()